### PR TITLE
[WIP] Throw UnauthorizedException when 403 response code is received.

### DIFF
--- a/src/Flubit/Client/Client.php
+++ b/src/Flubit/Client/Client.php
@@ -435,7 +435,7 @@ EOH;
                     array()
                     );
             
-            if ($statusCode === 401) {
+            if (in_array($statusCode, array(401,403))) {
 
                 throw new UnauthorizedException(is_object($xml) ? $xml->asXML() : json_encode($xml, JSON_PRETTY_PRINT), $statusCode);
             } else {


### PR DESCRIPTION
At the moment, the PHP Client only throws an UnauthorizedException in the case of a 401 response.

The inventory endpoint in Weflubit returns an empty JSON response (instead of an error) when it encounters an UnauthorizedException from the Client.
